### PR TITLE
minor-tweak

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+pythonenv*
+venv
+.venv
+.coverage
+.idea
+
+.DS_Store

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,6 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 indent = "    "
-# by default isort don't check module indexes
-not_skip = __init__.py
 # will group `import x` and `from x import` of the same module.
 force_sort_within_sections = true
 sections = FUTURE,STDLIB,INBETWEENS,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
- add .dockerignore
- not skip option is not need from isort 5.x
