### PR TITLE
Maintenance hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Acer Air Monitor",
-  "hacs": "1.21.0",
+  "hacs": "1.6.0",
   "domains": ["sensor"],
-  "homeassistant": "2022.2.2"
+  "homeassistant": "0.118.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "Acer Air Monitor",
   "hacs": "1.6.0",
-  "domains": ["sensor"],
   "homeassistant": "0.118.0"
 }


### PR DESCRIPTION
- Downgraded the minimum required Home Assistant version.
- Downgraded the minimum required HACS version.
- `domains` key has been removed.
